### PR TITLE
Correct hex for red orange 20%

### DIFF
--- a/identity/color-principles.md
+++ b/identity/color-principles.md
@@ -413,7 +413,7 @@ They should never overpower the core brand colors.
             <tbody>
                 <tr>
                     <th>HEX</th>
-                    <td>#E8A091</td> <!-- Update the hex code -->
+                    <td>#F6D9D3</td> <!-- Update the hex code -->
                 </tr>
                 <tr>
                     <th>RGB</th>


### PR DESCRIPTION
The hex for red orange 20% was actually for the 50%. Corrected.
