### PR TITLE
Change button to link

### DIFF
--- a/identity/minicons.md
+++ b/identity/minicons.md
@@ -192,6 +192,8 @@ Our full minicon set is available for desktop use as an icon font (.ttf). It can
 ### Vector files
 Each of our minicons is available for download as a vector (.svg) on The Noun Project, a platform that collects and catalogs icons that are created and uploaded by graphic designers from around the world.
 
+<a href="http://thenounproject.com/cfpb_minicons/">View on Noun Project <i class="cf-icon cf-icon-external-link"></i></a></span>
+
 <a class="icon-link icon-link__external-link" href="http://thenounproject.com/cfpb_minicons/" >
     <span class="icon-link_text">View on Noun Project</span>
 </a>

--- a/identity/minicons.md
+++ b/identity/minicons.md
@@ -192,7 +192,7 @@ Our full minicon set is available for desktop use as an icon font (.ttf). It can
 ### Vector files
 Each of our minicons is available for download as a vector (.svg) on The Noun Project, a platform that collects and catalogs icons that are created and uploaded by graphic designers from around the world.
 
-<a href="http://thenounproject.com/cfpb_minicons/">View on Noun Project <i class="cf-icon cf-icon-external-link"></i></a>
+<a href="http://thenounproject.com/cfpb_minicons/">View on Noun Project <i class="cf-icon icon-link__external-link"></i></a>
 
 <a class="icon-link icon-link__external-link" href="http://thenounproject.com/cfpb_minicons/" >
     <span class="icon-link_text">View on Noun Project</span>

--- a/identity/minicons.md
+++ b/identity/minicons.md
@@ -192,12 +192,6 @@ Our full minicon set is available for desktop use as an icon font (.ttf). It can
 ### Vector files
 Each of our minicons is available for download as a vector (.svg) on The Noun Project, a platform that collects and catalogs icons that are created and uploaded by graphic designers from around the world.
 
-<a href="http://thenounproject.com/cfpb_minicons/">View on Noun Project <i class="cf-icon icon-link__external-link"></i></a>
-
-<a class="icon-link icon-link__external-link" href="http://thenounproject.com/cfpb_minicons/" >
-    <span class="icon-link_text">View on Noun Project</span>
-</a>
-
 <a class="icon-link icon-link__external-link" href="http://thenounproject.com/cfpb_minicons/">
     View on Noun Project
 </a>

--- a/identity/minicons.md
+++ b/identity/minicons.md
@@ -198,4 +198,8 @@ Each of our minicons is available for download as a vector (.svg) on The Noun Pr
     <span class="icon-link_text">View on Noun Project</span>
 </a>
 
+<a class="icon-link icon-link__external-link" href="http://thenounproject.com/cfpb_minicons/">
+    View on Noun Project
+</a>
+
 </div>

--- a/identity/minicons.md
+++ b/identity/minicons.md
@@ -192,7 +192,7 @@ Our full minicon set is available for desktop use as an icon font (.ttf). It can
 ### Vector files
 Each of our minicons is available for download as a vector (.svg) on The Noun Project, a platform that collects and catalogs icons that are created and uploaded by graphic designers from around the world.
 
-<a href="http://thenounproject.com/cfpb_minicons/">View on Noun Project <i class="cf-icon cf-icon-external-link"></i></a></span>
+<a href="http://thenounproject.com/cfpb_minicons/">View on Noun Project <i class="cf-icon cf-icon-external-link"></i></a>
 
 <a class="icon-link icon-link__external-link" href="http://thenounproject.com/cfpb_minicons/" >
     <span class="icon-link_text">View on Noun Project</span>

--- a/identity/minicons.md
+++ b/identity/minicons.md
@@ -192,9 +192,8 @@ Our full minicon set is available for desktop use as an icon font (.ttf). It can
 ### Vector files
 Each of our minicons is available for download as a vector (.svg) on The Noun Project, a platform that collects and catalogs icons that are created and uploaded by graphic designers from around the world.
 
-<a href="http://thenounproject.com/cfpb_minicons/" target="_blank" class="btn">
-    <span class="btn_icon__left cf-icon cf-icon-external-link"></span>
-    View on Noun Project
+<a class="icon-link icon-link__external-link" href="http://thenounproject.com/cfpb_minicons/" >
+    <span class="icon-link_text">View on Noun Project</span>
 </a>
 
 </div>


### PR DESCRIPTION
Changing from button to link to The Noun Project

Note: the [code is copied directly from CF](https://cfpb.github.io/cf-typography/docs/#links-with-icons), but the displayed icon is wrong (it's `link`, not `external link`. Hoping this fixes itself once we update CF on the Design Manual.

```
<a class="icon-link icon-link__external-link" href="http://thenounproject.com/cfpb_minicons/">
    View on Noun Project
</a>
```

![image](https://cloud.githubusercontent.com/assets/1689222/5844573/098b888c-a183-11e4-9eca-f2a5fa4da504.png)
