### PR TITLE
Updated gem deps and instructions in readme for bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@
 source "https://rubygems.org"
 
 gem "github-pages"
-gem "kramdown"

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@
 source "https://rubygems.org"
 
 gem "github-pages"
+gem "kramdown"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  kramdown
 
 BUNDLED WITH
    1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,3 +124,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  kramdown
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ to your local machine.
 From the project directory, run Jekyll:
 
 ```sh
-jekyll serve --watch --baseurl ''
+bundle exec jekyll serve --watch --baseurl ''
 ```
 
 Open it up in your browser: <http://localhost:4000/>
@@ -183,7 +183,7 @@ The CFPB’s  Design & Development Team uses GitHub issues to track potential up
   - Ben Guhin (UX)
   - Scott Cranfill (FEWD)
   - Jennifer Horan (508)
-- After an issue has received the necessary approvals, anyone can volunteer to submit a pull request to make the change to the manual. Any applicable changes to our asset libraries and templates should also be updated on CFPB’s internal Google Drive. Any changes that require updates to a Capital Framework component should be made in the appropriate [GitHub repository](https://github.com/cfpb/capital-framework). 
+- After an issue has received the necessary approvals, anyone can volunteer to submit a pull request to make the change to the manual. Any applicable changes to our asset libraries and templates should also be updated on CFPB’s internal Google Drive. Any changes that require updates to a Capital Framework component should be made in the appropriate [GitHub repository](https://github.com/cfpb/capital-framework).
 
 ### Milestones
 
@@ -228,8 +228,8 @@ We recommend adding the following checklist to an issue when it's time to publis
 
 
 **3 - Publish** – When an issue has received all of the necessary approvals (which depends on the type of standard), move the issue to the milestone for ‘Publish.’ Be sure to tag how they need to be published from the options listed below.
-- Minicon font - All new minicons must have design approval before they are added to the minicon font. Once approved, an SVG file should be emailed to Daniel Pizarro. Updates to the minicon font are released every month or in an as needed basis. The updated file will be provided in a TrueType format (`.ttf`). 
-- Add to asset library – This is the responsibility of the designer or UX designer that volunteers for the issue. The final asset should either be added to the library or the template available on CFPB’s Google Drive. Examples of assets include the illustration library, isocon library, minicon font, cf.gov web templates, or print suite templates. Changes to the minicon font must go through Daniel Pizarro, are released in batches, and require more lead time. 
+- Minicon font - All new minicons must have design approval before they are added to the minicon font. Once approved, an SVG file should be emailed to Daniel Pizarro. Updates to the minicon font are released every month or in an as needed basis. The updated file will be provided in a TrueType format (`.ttf`).
+- Add to asset library – This is the responsibility of the designer or UX designer that volunteers for the issue. The final asset should either be added to the library or the template available on CFPB’s Google Drive. Examples of assets include the illustration library, isocon library, minicon font, cf.gov web templates, or print suite templates. Changes to the minicon font must go through Daniel Pizarro, are released in batches, and require more lead time.
 - Content update – Basic content update that can be done by anyone on the team.
 - FEWD task – Content that needs to be added to the Design Manual by a front end web developer. For the new content to be properly demonstrated in the manual, a CF component may be required.
 


### PR DESCRIPTION
Kramdown should be listed as a dependency to be installed by bundler. Bundler also requires `bundle exec` before ruby commands to work.
