### PR TITLE
Remove an extra li tag

### DIFF
--- a/ui-toolkit/modals.md
+++ b/ui-toolkit/modals.md
@@ -106,8 +106,6 @@ category: UI toolkit
     <li>Text size body: 16px</li>
     <li>Text size header: 22px</li>
     <li>Top border: 3px {% assign color = site.data.colors["green"] %} {{ color.name }} #{{ color.hex }}</li>
-
-</li>
   </ul>
 
 <h4 id="close">Close area</h4>


### PR DESCRIPTION
This was on the live site, after the recent merge:

![screen shot 2017-01-13 at 1 49 48 pm](https://cloud.githubusercontent.com/assets/1183435/21942042/66a32f0c-d999-11e6-8397-89a0cb6d6062.png)

## Removals

- Delete an extra `li` tag

## Review

- @jimmynotjim 

[Preview this PR without the whitespace changes](?w=0)

## Notes

I started this PR from the browser rather than my local fork, so I missed fixing the leading for the following `ul` tag.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
