### PR TITLE
Closing the gap on Design Manual and Capital Framework workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 https://cfpb.github.io/design-manual/
 
-This is the repository for CFPB's Design Manual for developing print and web products. It contains both the assets and the content for the site.
+This is the repository for CFPB's Design Manual for developing print and web
+products. It contains both the assets and the content for the site.
 
-This Design Manual is an open-source resource for CFPB staff to produce effective and visually-consistent products that are easy for consumers to access, use, and understand. The Manual includes our design principles, guidelines for user experience, visual identity standards, and code snippets for common user interface elements. The Manual will continue to evolve as we learn what works best for the CFPB and the people we serve.
+This Design Manual is an open-source resource for CFPB staff to produce
+effective and visually-consistent products that are easy for consumers to
+access, use, and understand. The Manual includes our design principles,
+guidelines for user experience, visual identity standards, and code snippets
+for common user interface elements. The Manual will continue to evolve as we
+learn what works best for the CFPB and the people we serve.
 
-These standards reflect our latest thinking and are a work-in-progress. Our goal is to apply them to all of CFPB projects.
+These standards reflect our latest thinking and are a work-in-progress. Our
+goal is to apply them to all of CFPB projects.
 
 We are proud to join the community of organizations that have made their
 design standards public, such as
@@ -21,76 +28,65 @@ CC0 1.0 Universal Public Domain Dedication, and we'd love for other agencies,
 developers, or groups to adapt it for their own use.
 
 
-## Running it locally
+## Technology stack
 
-Content editors and developers probably want to set up the Design Manual on
-their local machine so they can preview updates without pushing to GitHub.
-
-Before you get started make sure you have an up-to-date version of Ruby and Bundler.
-We use [Homebrew](http://brew.sh/):
-
-```sh
-brew install ruby
-gem install bundler
-```
-
-As the site is intended to be deployed on GitHub Pages, installing the
-GitHub Pages gem is the best way to install Jekyll and related dependencies.
-Run the following command to install it:
-
-```sh
-bundle install
-```
-
-[Fork and clone the repo](https://help.github.com/articles/fork-a-repo/)
-to your local machine.
-
-From the project directory, run Jekyll:
-
-```sh
-bundle exec jekyll serve --watch --baseurl ''
-```
-
-Open it up in your browser: <http://localhost:4000/>
-
-
-## Working with the front end
-
-The Design Manual front end currently uses the following:
-
-- [Grunt](http://gruntjs.com/): Task runner for pulling in assets,
+- [Ruby](https://www.ruby-lang.org/en/) - For installing Jekyll.
+- [Jekyll](http://jekyllrb.com/) - Static site server.
+- [Node](https://nodejs.org/en/) - For managing front-end dependencies.
+- [Grunt](http://gruntjs.com/) - Task runner for pulling in assets,
   linting and concatenating code, etc.
-- [Less](http://lesscss.org/): CSS pre-processor.
-- [Capital Framework](https://cfpb.github.io/capital-framework/):
+- [Less](http://lesscss.org/) - CSS pre-processor.
+- [Capital Framework](https://cfpb.github.io/capital-framework/) -
   User interface pattern-library produced by the CFPB.
-- [Jekyll](http://jekyllrb.com/): Static site generator used by GitHub Pages.
 
 **NOTE:** If you're new to Capital Framework, we encourage you to
 [start here](https://cfpb.github.io/capital-framework/getting-started).
 
-### Installing dependencies (one time)
 
-1. Install [node.js](http://nodejs.org/) however you'd like.
-2. Install [Grunt](http://gruntjs.com/) globally:
+## Installation
 
-```sh
-npm install -g grunt-cli
+This site is powered by Jekyll a Ruby based static site generator. For
+front-end tooling and asset management we use Node and Grunt. Before
+running the site locally you will need these dependencies. We use
+[homebrew](http://brew.sh/) on Mac OSX to manage installation of software.
+To install the project dependencies using homebrew enter the following:
+
+```shell
+brew install ruby
+brew install node
+gem install jekyll
+npm install --global grunt-cli
 ```
+
+To install the site's dependencies, navigate to the project directory and run:
+
+```shell
+./setup.sh
+```
+
+To launch the site, enter:
+
+```shell
+npm start
+```
+
+This will start the Jekyll server and the Grunt watch task. Open a browser
+window at http://localhost:4000.
 
 ### Developing
 
 When first setting up this project, and each time you fetch from upstream,
 run the setup shell script to install the newest project dependencies and
-build the website with grunt:
+build the website with Grunt:
 
 ```sh
 ./setup.sh
 ```
 
-We use [Grunt](http://gruntjs.com/) to compile and compress
-our Less and JavaScript files.
-The easiest way to do that is to run the `watch` task.
-This will watch for changes and run `grunt` whenever you save a CSS or JS file:
+We use Grunt to build our asset files. The easiest way to do that is to run
+the `watch` task which will monitor file changes and re-build the assets
+whenever you save a CSS or JS file
+(**Note: This is running when you run `npm start`, no need to run it twice**):
 
 ```
 grunt watch
@@ -151,7 +147,10 @@ which is the front-end pattern library used in this project.
 
 ## How to track an issue
 
-The CFPB’s Design & Development Team uses GitHub issues to track potential updates and additions to the CFPB Design Manual. We welcome the public to participate in our discussions and in opening pull requests to the Design Manual.
+The CFPB’s Design & Development Team uses GitHub issues to track potential
+updates and additions to the CFPB Design Manual. We welcome the public to
+participate in our discussions and in opening pull requests to the
+Design Manual.
 
 **Design Manual Product Co-owners:**<br>
 Each discipline, UX and GD, has a representative<br>
@@ -168,47 +167,87 @@ Scott Cranfill (FEWD)
 ## Process
 
 **1. Create MVP**<br>
-We work through open issues during group hack hours. During hack hours, you should choose an issue that has been prioritized with the “Hack hours” milestone, form small teams, and work to complete an MVP by the end of the session. This could mean completing the issue, providing a written recommendation, or simply outlining a plan for next steps. The goal will be to add something live to the Manual as a way to provide guidance to the rest of the team on that issue, as well as keeping the Manual a current source of our standards.
+We work through open issues during group hack hours. During hack hours, you
+should choose an issue that has been prioritized with the “Hack hours”
+milestone, form small teams, and work to complete an MVP by the end of the
+session. This could mean completing the issue, providing a written
+recommendation, or simply outlining a plan for next steps. The goal will be
+to add something live to the Manual as a way to provide guidance to the rest
+of the team on that issue, as well as keeping the Manual a current source of
+our standards.
 
 **2. Review**<br>
-Updates and additions are ready for publishing after an issue has been: 
-- reviewed and agreed upon by a combination of 3-4 user experience and graphic designers 
+Updates and additions are ready for publishing after an issue has been:
+- reviewed and agreed upon by a combination of 3-4 user experience and graphic
+designers
 - content follows DM standards and is reviewed by the Manual content strategist
-- reviewed by one of the FEWD Primary Maintainers to help spot any problems from a development perspective
+- reviewed by one of the FEWD Primary Maintainers to help spot any problems
+from a development perspective
 
 **3. Submit pull request**<br>
-After review is complete, anyone can submit a pull request to merge the update. The Primary Maintainers are responsible for reviewing and merging pull requests.
+After review is complete, anyone can submit a pull request to merge the update.
+The Primary Maintainers are responsible for reviewing and merging pull requests.
 
-The issue will be added to the Capital Framework backlog to be prioritized in upcoming sprints. DM Product Co-owners will attend CF backlog grooming sessions to assist in prioritizing issues.
+The issue will be added to the Capital Framework backlog to be prioritized in
+upcoming sprints. DM Product Co-owners will attend CF backlog grooming sessions
+to assist in prioritizing issues.
 
 **4. Add patterns to design library**<br>
-After the update has been merged and is live on the Manual, add .ai pattern files to the design library in the folder ‘New patterns’ within website templates for consumerfinance.gov on CFPB’s Google Drive.
+After the update has been merged and is live on the Manual, add .ai pattern
+files to the design library in the folder ‘New patterns’ within website
+templates for consumerfinance.gov on CFPB’s Google Drive.
 
 ## Assigning labels to your issue
 
 **Where is it within the process?**<br>
-1 - Working – apply this to issues you are working on during current hack hours sprint.<br>
-2 - Peer review – apply this to issues that need peer review before going live. The page should be reviewed in it’s entirety, including content, before being published to the Design Manual.
+1 - Working – apply this to issues you are working on during current hack
+hours sprint.<br>
+2 - Peer review – apply this to issues that need peer review before going
+live. The page should be reviewed in it’s entirety, including content, before
+being published to the Design Manual.
 
 ## Milestones
-Hack hours – This milestone will be named with the month of the upcoming hack hour, for example “February hack hours.” Issues for that session will be prioritized and assigned this milestone in advance by DM Product Co-owners.
+Hack hours – This milestone will be named with the month of the upcoming hack
+hour, for example “February hack hours.” Issues for that session will be
+prioritized and assigned this milestone in advance by DM Product Co-owners.
 
 
 ## Expedited review for component or template updates
-In general, we try to build using our templated components to create a consistent user experience and visual design across CFPB web products. If a project team encounters a use case in which they need a template change, a component change, and/or an entirely new template or component, please follow the expedited review process: 
+In general, we try to build using our templated components to create a consistent
+user experience and visual design across CFPB web products. If a project team
+encounters a use case in which they need a template change, a component change,
+and/or an entirely new template or component, please follow the expedited review
+process:
 
-1. Submit an issue to this repo requesting a review of your proposed change. @ mention DM lead reviewers (as noted above) and CF.gov Product Owner (currently Jessica Schafer).
- - Be sure to include your business or user experience justification for the proposed change.
- - The issue should include both a quick illustration or demo of how the new use case would be handled by established components/templates (if it can be handled at all) and how the use case would be handled by your update or addition. 
-2. DM lead reviewers and CF.gov Product Owner have 1 week for discussion and consideration of the change. (Comments from others encouraged and welcome!) If consensus is not reached by the end of the week, the CF.gov Product Owner will make a decision.
-3. If approved, add the “Approved concept” and “Documentation needed” tags to the issue and implement the change within your project work. 
- - If moving forward with the change requires modifications to our CMS code, the project team will take the lead with support from the CF.gov Platform Team.
+1. Submit an issue to this repo requesting a review of your proposed change.
+@ mention DM lead reviewers (as noted above) and CF.gov Product Owner
+(currently Jessica Schafer).
+ - Be sure to include your business or user experience justification for the
+ proposed change.
+ - The issue should include both a quick illustration or demo of how the new
+ use case would be handled by established components/templates (if it can be
+ handled at all) and how the use case would be handled by your update or
+ addition.
+2. DM lead reviewers and CF.gov Product Owner have 1 week for discussion and
+consideration of the change. (Comments from others encouraged and welcome!)
+If consensus is not reached by the end of the week, the CF.gov Product Owner
+will make a decision.
+3. If approved, add the “Approved concept” and “Documentation needed” tags to
+the issue and implement the change within your project work.
+ - If moving forward with the change requires modifications to our CMS code,
+ the project team will take the lead with support from the CF.gov Platform
+ Team.
 
-By the time the project ends, Design Manual and Capital Framework documentation should be updated to reflect the change per the existing processes described above:
+By the time the project ends, Design Manual and Capital Framework documentation
+should be updated to reflect the change per the existing processes described
+above:
 
-- Team updates existing DM page or creates a new one to be published. Mark all approval labels that apply per standard DM process.
-- Once all of approval labels have been removed by discipline leads, team implements changes:
- - Update Capital Framework (ideally this will be done as part of project work)
+- Team updates existing DM page or creates a new one to be published. Mark all
+approval labels that apply per standard DM process.
+- Once all of approval labels have been removed by discipline leads, team
+implements changes:
+ - Update Capital Framework (ideally this will be done as part of project
+ work)
  - Add to the Design Manual
  - Add assets to design libraries
 

--- a/package.json
+++ b/package.json
@@ -1,17 +1,21 @@
 {
   "name": "design-manual",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A set of design principles and standards for the Consumer Financial Protection Bureau.",
   "homepage": "http://cfpb.github.io/design-manual/",
   "author": {
     "name": "Consumer Financial Protection Bureau",
-    "email": "tech@cfpb.gov"  ,
-        "url": "http://consumerfinance.gov"
+    "email": "tech@cfpb.gov",
+    "url": "http://consumerfinance.gov"
   },
   "license": "CC0",
   "keywords": [
     "design-manual"
   ],
+  "scripts": {
+    "start": "parallelshell 'bundle exec jekyll serve --watch --baseurl ''' 'grunt watch'",
+    "build": "grunt build"
+  },
   "dependencies": {
     "cf-buttons": "^3.2.0",
     "cf-core": "^3.5.0",
@@ -46,6 +50,7 @@
     "grunt-string-replace": "~1.0.0",
     "grunt-topdoc": "~0.3.0",
     "load-grunt-tasks": "~1.0.0",
+    "parallelshell": "^2.0.0",
     "time-grunt": "~1.0.0"
   }
 }


### PR DESCRIPTION
Aligned the Design Manual front-end workflow with the Capital Framework front-end workflow

## Additions

- Added NPM script to bundle the Jekyll server and Grunt watch as one command

## Changes

- Updated the README to better describe our stack
- Updated the README to simplify the front-end instructions
- Updated the README to conform to 80 char line limits (where possible)

## Testing

- Pull in this branch and follow the installation instructions
- Run the `npm start` command
- Open a browser to `http://localhost:4000/

## Review

- @Scotchester
- @ascott1

[Preview this PR without the whitespace changes](?w=0)

## Todos

- We should eventually upgrade this project to use Gulp to keep the front-end workflow more uniform, but this takes care of a lot.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
