### PR TITLE
Revert "Added data-viz nav item"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,9 +60,9 @@ mainnav:
 - text: Page components
   url: page-components/page-components.html
   internal: true
-- text: Data visualization
-  url: data-visualization/data-visualization.html
-  internal: true
+# - text: Data visualization
+#   url: data-visualization/data-visualization.html
+#   internal: true
 
 # Secondary Navigation
 # List links that should appear in the secondary navigation (sidebar) here


### PR DESCRIPTION
Reverts cfpb/design-manual#455, because the Data Visualization page has no content yet.