### PR TITLE
Adding clarification for responsive pattern of fixed-width columns

### DIFF
--- a/page-components/tables.md
+++ b/page-components/tables.md
@@ -1000,6 +1000,8 @@ Left-align columns of nominal numbers (ZIP codes, room numbers) or non-numeric v
 <h3 class="h4">Fixed-width columns</h3>
 
 Column widths are automatically set by browsers by default. If needed, some or all columns can be set to specific widths instead to accommodate longer data or labels.
+
+Fixed-width columns at the 600 px breakpoint and less lose their custom widths and expand to full width. This is the same responsive pattern used for default tables at small screens.
 </div>
 <div class="content-50 content-last">
 {::nomarkdown}


### PR DESCRIPTION
Adding one sentence under "Fixed-width columns" on the Tables page to clarify the responsive pattern for breakpoints 600 and less. Chuck and our team have been working on implementing this for use in the CMS and wanted to document the responsive pattern.

## Review

- @marteki 
- @mistergone
- @schaferjh 
- @jimmynotjim 
- @Scotchester 
- @caheberer   

[Preview this PR without the whitespace changes](https://github.com/cfpb/design-manual/compare/gh-pages...ajbush-patch-1-1?w=0)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
