### PR TITLE
Fix source location of cf-icons fonts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -194,15 +194,6 @@ module.exports = function(grunt) {
         files: [
           {
             expand: true,
-            cwd: '<%= loc.src %>',
-            src: [
-              // HTML files
-              '*.html',
-            ],
-            dest: '<%= loc.dist %>'
-          },
-          {
-            expand: true,
             cwd: '<%= loc.modules %>/cf-icons/src',
             src: [
               // Fonts

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -203,7 +203,7 @@ module.exports = function(grunt) {
           },
           {
             expand: true,
-            cwd: '<%= loc.src %>/static',
+            cwd: '<%= loc.modules %>/cf-icons/src',
             src: [
               // Fonts
               'fonts/*'
@@ -310,10 +310,6 @@ module.exports = function(grunt) {
       js: {
         files: ['Gruntfile.js', '<%= loc.src %>/static/js/**/*.js'],
         tasks: ['js']
-      },
-      content: {
-        files: ['**/*.html', '/downloads/*.md', '/guides/*.md', '/identity/*.md', '/ui-toolkit/*.md'],
-        tasks: ['copy']
       }
     }
 


### PR DESCRIPTION
## Changes

- Source of font files in the Grunt copy task is now the cf-icons package


## Removals

- Stop unnecessarily watching content files, since Jekyll watch handles that.


## Testing

- `grunt copy -v` and verify that the cf-icons font files are copied from `node_modules/cf-icons/src/fonts` to `static/fonts`

[Preview this PR without the whitespace changes](?w=0)


## Screenshots

![screen shot 2017-04-28 at 14 36 25](https://cloud.githubusercontent.com/assets/1044670/25542339/1ec89e72-2c20-11e7-8dd5-d296c07cd532.png)


## Notes

- As discussed with @jimmynotjim, these tasks need a bigger overhaul in the near future, and probably a migration to Gulp, which seems to be what we're standardizing on. This is just a couple small band-aids.


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
