### PR TITLE
Correct color naming for accessible combinations

### DIFF
--- a/brand-guidelines/typography.md
+++ b/brand-guidelines/typography.md
@@ -411,7 +411,7 @@ Use only these accessible text and background color combinations.
         <li class="type-color-combo__black-on-white">Black on White</li>
         <li class="type-color-combo__dark-gray-on-white">Dark Gray on White</li>
         <li class="type-color-combo__white-on-black">White on Black</li>
-        <li class="type-color-combo__white-on-darkgray">White on Dark Gray</li>
+        <li class="type-color-combo__white-on-dark-gray">White on Dark Gray</li>
         <li class="type-color-combo__black-on-gray10">Black on Gray 10</li>
         <li class="type-color-combo__black-on-gray5">Black on Gray 5</li>
         <li class="type-color-combo__pacific-on-gray5">Pacific on Gray 5</li>

--- a/brand-guidelines/typography.md
+++ b/brand-guidelines/typography.md
@@ -430,7 +430,7 @@ Use only these accessible text and background color combinations.
 
 <h3 class="warning"><span class="cf-icon cf-icon-delete-round"></span> Non-accessible combinations</h3>
 
-Never set CFPB Green type on a White background or White type on CFPB Green background as these combinations are not accessible. Never set type on a patterned background.
+Never set CFPB Green type on a white background or white type on CFPB Green background as these combinations are not accessible. Never set type on a patterned background.
 
 </div>
 
@@ -453,7 +453,7 @@ Never set CFPB Green type on a White background or White type on CFPB Green back
 
 <h3 class="warning"><span class="cf-icon cf-icon-delete-round"></span> Undesirable combinations</h3>
 
-Although CFPB Green and Black are accessible for large scale type, this color combination should never be used for web or print type.
+Although CFPB Green and black are accessible for large scale type, this color combination should never be used for web or print type.
 
 </div>
 

--- a/brand-guidelines/typography.md
+++ b/brand-guidelines/typography.md
@@ -412,9 +412,9 @@ Use only these accessible text and background color combinations.
         <li class="type-color-combo__dark-gray-on-white">Dark Gray on White</li>
         <li class="type-color-combo__white-on-black">White on Black</li>
         <li class="type-color-combo__white-on-darkgray">White on Dark Gray</li>
-        <li class="type-color-combo__black-on-gray-10">Black on Gray 10</li>
-        <li class="type-color-combo__black-on-gray-5">Black on Gray 5</li>
-        <li class="type-color-combo__pacific-on-gray-5">Pacific on Gray 5</li>
+        <li class="type-color-combo__black-on-gray10">Black on Gray 10</li>
+        <li class="type-color-combo__black-on-gray5">Black on Gray 5</li>
+        <li class="type-color-combo__pacific-on-gray5">Pacific on Gray 5</li>
         <li class="type-color-combo__black-on-greenmid">Black on Green 60</li>
         <li class="type-color-combo__black-on-greentint">Black on Green 20</li>
     </ul>

--- a/brand-guidelines/typography.md
+++ b/brand-guidelines/typography.md
@@ -17,7 +17,7 @@ redirect_from: "/identity/typography.html"
 
 <div class="content-67 content-first">
 
-A clear typographic hierarchy is critical to the effective communication of our brand. Type should be light and well-spaced to reinforce the idea that the CFPB is open, modern, and approachable. It should promote readability and accessibility, which allows all users to efficiently read and absorb textual information. This system uses weight, scale, and capitalization to convey the relative importance of each heading within a document.
+A clear typographic hierarchy is critical to the effective communication of our brand. Type should be light and well-spaced to reinforce that we are transparent, open, and approachable. This system uses weight, scale, and capitalization to convey the relative importance of each heading within a document. Readability and accessibility allow all users to efficiently read and absorb textual information. 
 {: class="lead-in"}
 
 </div>
@@ -89,7 +89,7 @@ abcdefghijklmnopqrstuvwxyz
 
 ## Web hierarchy
 
-<p>Hierarchy refers to the difference in type size and weight between text elements. It creates focus points that signal the user where to read; a successful hierarchy enables readers to easily scan content.</p>
+<p>Hierarchy refers to the difference in type size and weight between text elements. It creates focus points that signal the user where to read. A successful hierarchy enables readers to easily scan content.</p>
 
 ### Headings
 
@@ -398,7 +398,7 @@ is a useful resource for testing the compliance of any combination of colors in 
 
 ### Fully accessible combinations
 
-Accessible text and background color combinations are shown below:
+Use only these permitted accessible text and background color combinations.
 
 </div>
 
@@ -409,14 +409,14 @@ Accessible text and background color combinations are shown below:
 <figure>
     <ul>
         <li class="type-color-combo__black-on-white">Black on White</li>
-        <li class="type-color-combo__darkgray-on-white">Dark Gray on White</li>
+        <li class="type-color-combo__dark-gray-on-white">Dark Gray on White</li>
         <li class="type-color-combo__white-on-black">White on Black</li>
         <li class="type-color-combo__white-on-darkgray">White on Dark Gray</li>
-        <li class="type-color-combo__black-on-gray10">Black on Gray 10</li>
-        <li class="type-color-combo__black-on-gray5">Black on Gray 5</li>
-        <li class="type-color-combo__pacific-on-gray5">Pacific on Gray 5</li>
-        <li class="type-color-combo__black-on-green60">Black on Green 60</li>
-        <li class="type-color-combo__black-on-green20">Black on Green 20</li>
+        <li class="type-color-combo__black-on-gray-10">Black on Gray 10</li>
+        <li class="type-color-combo__black-on-gray-5">Black on Gray 5</li>
+        <li class="type-color-combo__pacific-on-gray-5">Pacific on Gray 5</li>
+        <li class="type-color-combo__black-on-greenmid">Black on Green 60</li>
+        <li class="type-color-combo__black-on-greentint">Black on Green 20</li>
     </ul>
 </figure>
 
@@ -427,7 +427,7 @@ Accessible text and background color combinations are shown below:
 <div class="content-33 content-first">
 
 ### Partially accessible combinations
-Black or White text on Gray, and Gray text on white are _only accessible for text sizes above 24px_.
+White text on Gray and Gray text on White are _only accessible for text sizes above 24px_.
 
 </div>
 
@@ -438,7 +438,6 @@ Black or White text on Gray, and Gray text on white are _only accessible for tex
 <figure>
     <ul>
         <li class="type-color-combo__white-on-gray">White on Gray</li>
-        <li class="type-color-combo__black-on-gray">Black on Gray</li>
         <li class="type-color-combo__gray-on-white">Gray on White</li>
     </ul>
 </figure>
@@ -451,7 +450,7 @@ Black or White text on Gray, and Gray text on white are _only accessible for tex
 
 <h3 class="warning"><span class="cf-icon cf-icon-delete-round"></span> Non-accessible combinations</h3>
 
-Never set CFPB Green type on a white background or White type on CFPB Green background as these combinations are not accessible. Never set type on a patterned background.
+Never set CFPB Green type on a White background or White type on CFPB Green background as these combinations are not accessible. Never set type on a patterned background.
 
 </div>
 

--- a/brand-guidelines/typography.md
+++ b/brand-guidelines/typography.md
@@ -427,7 +427,7 @@ Use only these accessible text and background color combinations.
 <div class="content-33 content-first">
 
 ### Partially accessible combinations
-White text on Gray and Gray text on White are _only accessible for text sizes above 24px_.
+White text on Gray and Gray text on White are only accessible for text sizes above 24px.
 
 </div>
 

--- a/brand-guidelines/typography.md
+++ b/brand-guidelines/typography.md
@@ -410,35 +410,15 @@ Use only these accessible text and background color combinations.
     <ul>
         <li class="type-color-combo__black-on-white">Black on White</li>
         <li class="type-color-combo__dark-gray-on-white">Dark Gray on White</li>
+        <li class="type-color-combo__gray-on-white">Gray on White</li> 
         <li class="type-color-combo__white-on-black">White on Black</li>
         <li class="type-color-combo__white-on-dark-gray">White on Dark Gray</li>
+        <li class="type-color-combo__white-on-gray">White on Gray</li>
         <li class="type-color-combo__black-on-gray10">Black on Gray 10</li>
         <li class="type-color-combo__black-on-gray5">Black on Gray 5</li>
         <li class="type-color-combo__pacific-on-gray5">Pacific on Gray 5</li>
         <li class="type-color-combo__black-on-greenmid">Black on Green 60</li>
         <li class="type-color-combo__black-on-greentint">Black on Green 20</li>
-    </ul>
-</figure>
-
-{:/nomarkdown}
-
-</div>
-
-<div class="content-33 content-first">
-
-### Partially accessible combinations
-White text on Gray and Gray text on White are only accessible for text sizes above 24px.
-
-</div>
-
-<div class="content-67 content-last">
-
-{::nomarkdown}
-
-<figure>
-    <ul>
-        <li class="type-color-combo__white-on-gray">White on Gray</li>
-        <li class="type-color-combo__gray-on-white">Gray on White</li>
     </ul>
 </figure>
 

--- a/brand-guidelines/typography.md
+++ b/brand-guidelines/typography.md
@@ -398,7 +398,7 @@ is a useful resource for testing the compliance of any combination of colors in 
 
 ### Fully accessible combinations
 
-Use only these permitted accessible text and background color combinations.
+Use only these accessible text and background color combinations.
 
 </div>
 


### PR DESCRIPTION
## Additions
- Minor content updates to intro text

## Removals
- Removed Black on Gray option for large type (discussed with @caheberer and we agreed that we don't want to encourage the use of this combination as it is difficult to read).

## Changes
- Corrected the color naming for the accessible combinations so that it maps correctly. I was using "green-20" and "green-60" but this didn't map. So, I changed back to "greenmid" and "greentint" (this is in <li class="type-color-combo__"). Since I can use the previous naming convention and still get the right visual result (and correct hex values) I'm moving forward with that approach). 

## Testing

-

## Review

- @caheberer 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots
**Before:** 
<img width="852" alt="screen shot 2017-08-16 at 12 52 16 pm" src="https://user-images.githubusercontent.com/6887128/29376862-fb6c578e-8287-11e7-9f0b-0a2b2f933aa8.png">

**After**
<img width="930" alt="screen shot 2017-08-16 at 1 54 28 pm" src="https://user-images.githubusercontent.com/6887128/29377684-8b448032-828a-11e7-8f44-53cb581775a1.png">

## Notes
- @caheberer - I moved Gray on White and White on Gray to the accessible combinations since, according to the [color contrast tool](https://accessibility.oit.ncsu.edu/tools/color-contrast/accessible-color-palette.php?&colors=1e9642,20aa3f,66c368,addc91,c7e5b3,e2efd8,005e5d,257675,579695,89b6b5,b4d2d1,d4e7e6,0050b4,0072ce,4497dc,7eb7e8,afd2f2,d6e8fa,002d72,254b87,5674a3,889cc0,b3c0d9,d3daeb,a01b68,b4267a,c55998,d486b2,e3b2cc,f0d8e2,b63014,d14124,dd735d,e79e8e,f0c3b8,f7e0d9,dc731c,ff9e1b,ffb858,ffce8d,ffe1b9,fff0dd,745745,8a6c57,a18573,baa496,d3c5bc,e7ddd7,101820,43484e,5a5d61,75787b,919395,b4b5b6,d2d3d5,e7e8e9,f7f8f9,ffffff&main=ffffff&level=AA) this is now accessible at all sizes. 

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
