### PR TITLE
Fixes jshint warning

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -264,7 +264,8 @@ module.exports = function(grunt) {
           define: true,
           console: true,
           EventEmitter: true
-        }
+        },
+        reporterOutput: ''
       },
       all: ['<%= loc.src %>/static/js/app.js']
     },


### PR DESCRIPTION
`reporterOutput` needs to be an empty string or jshint reports an error. By default it's `null`, not a string, so needs to be explicitly set to a string.

## Changes

- Sets `jshint` task's `reporterOutput` option to an empty string.

## Testing

- `grunt build` should report no warnings from jshint.
