### PR TITLE
Updates dependencies

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Redirects
-gems:
+plugins:
   - jekyll-redirect-from
 
 # Base configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -657,6 +657,15 @@
         "cf-grid": "4.2.2"
       }
     },
+    "cf-notifications": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cf-notifications/-/cf-notifications-1.0.2.tgz",
+      "integrity": "sha512-XECEXwToP0NSkoMwYMteRy+R9NQLSzP38n/G0B3F94fiAGUVuPX8QsjHQW0m+2wP6xQmsdfQAdICNCJG94R/Lg==",
+      "requires": {
+        "cf-core": "4.4.1",
+        "cf-icons": "4.2.1"
+      }
+    },
     "cf-pagination": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/cf-pagination/-/cf-pagination-4.2.1.tgz",
@@ -3073,15 +3082,21 @@
       }
     },
     "grunt-contrib-uglify": {
-      "version": "git+https://github.com/gruntjs/grunt-contrib-uglify.git#c2ccee1b61a585c5f4fca00da8f79cc1db37048b",
+      "version": "git+https://github.com/gruntjs/grunt-contrib-uglify.git#049052f76c5b6e80ac1d7d256f4c450f00067936",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "maxmin": "1.1.0",
-        "uglify-es": "3.0.28",
+        "uglify-es": "3.1.0",
         "uri-path": "1.0.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
         "gzip-size": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
@@ -3112,6 +3127,16 @@
           "requires": {
             "get-stdin": "4.0.1",
             "meow": "3.7.0"
+          }
+        },
+        "uglify-es": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.0.tgz",
+          "integrity": "sha512-368gRJ/ww3e9c8eJLAFM6sco4ndsg7d2MskNusejep0kvd7VCqNj/q/zrDG/1KwS+EWfTxJKTj7UyLN+zz+gyg==",
+          "dev": true,
+          "requires": {
+            "commander": "2.11.0",
+            "source-map": "0.5.7"
           }
         }
       }
@@ -4547,9 +4572,9 @@
       "dev": true
     },
     "parallelshell": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parallelshell/-/parallelshell-2.0.0.tgz",
-      "integrity": "sha1-yUr11jSFJqJtqQIPrrX8ckqAYAw=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/parallelshell/-/parallelshell-3.0.1.tgz",
+      "integrity": "sha512-xsSQGhJTFjbSW3WGsnSFTg1G17dcDU+gMH7bWxjAiy/3H579KPFbSp3fhkZ+jx2wcZuoav46nq+QVX0I0xPcyA==",
       "dev": true
     },
     "parents": {
@@ -5753,9 +5778,9 @@
       "dev": true
     },
     "uglify-es": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.0.28.tgz",
-      "integrity": "sha512-xw1hJsSp361OO0Sq0XvNyTI2wfQ4eKNljfSYyeYX/dz9lKEDj+DK+A8CzB0NmoCwWX1MnEx9f16HlkKXyG65CQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.0.tgz",
+      "integrity": "sha512-368gRJ/ww3e9c8eJLAFM6sco4ndsg7d2MskNusejep0kvd7VCqNj/q/zrDG/1KwS+EWfTxJKTj7UyLN+zz+gyg==",
       "dev": true,
       "requires": {
         "commander": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "normalize-legacy-addon": "0.1.0"
   },
   "devDependencies": {
-    "csv": "^1.1.1",
     "child-process-promise": "^2.2.0",
+    "csv": "^1.1.1",
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "~2.0.0",
     "grunt-banner": "~0.2.3",
@@ -57,7 +57,8 @@
     "grunt-topdoc": "~0.3.0",
     "load-grunt-tasks": "~1.0.0",
     "moment": "^2.17.1",
-    "parallelshell": "^2.0.0",
-    "time-grunt": "~1.0.0"
+    "parallelshell": "^3.0.0",
+    "time-grunt": "~1.0.0",
+    "uglify-es": "^3.1.0"
   }
 }


### PR DESCRIPTION
## Changes

- Updates parallelshell to the latest (I have an issue with the prior version when a second server is running locally).
- Updates deprecated `gems` syntax in `_config.yml` to `plugins`.
- Adds `uglify-es` to dev dependencies and associated packages via `npm install uglify-es --save-dev`. `grunt build` was saying it was not found before.
- Re-generates `package-lock.json`.

## Testing

- `npm install && grunt build && npm start` should be error-free.