### PR TITLE
Separated out "Large target areas" into its own section within forms page

### DIFF
--- a/page-components/form-fields.md
+++ b/page-components/form-fields.md
@@ -11,6 +11,7 @@ redirect_from: "/ui-toolkit/form-fields.html"
 - [Notifications](#notifications)
 - [Checkboxes](#checkboxes)
 - [Radio buttons](#radio-buttons)
+- [Large target areas](#large-target-areas)
 - [Dropdowns](#dropdowns)
 - [Range sliders](#range-sliders)
 {: class="toc"}
@@ -111,7 +112,7 @@ Users of screen readers use the tab key to move focus from one form control to a
 <div class="content-50 content-last">
 
 {::nomarkdown}
-<input class="a-text-input a-text-input__hover" placeholder="Placeholder text" type="text">
+<input class="a-text-input a-text-input__focused" placeholder="Placeholder text" type="text">
 {:/nomarkdown}
 
 </div>
@@ -612,7 +613,7 @@ The error notification displays when an operation has not run as expected and en
 
 <div class="content-66 content-first">
 
-<!--******************************-    CHECKBOXES AND RADIO BUTTONS     ******************************-->
+<!--******************************-    CHECKBOXES AND RADIO BUTTONS ******************************-->
 
 <br>
 
@@ -675,7 +676,6 @@ To optimize screen reader accessibility, lay out checkboxes vertically rather th
     <input class="a-checkbox hover" type="checkbox" id="test_checkbox_basic_hover">
     <label class="a-label" for="test_checkbox_basic_hover">Label</label>
 </div>
-
 {:/nomarkdown}
 
 </div>
@@ -694,10 +694,9 @@ To optimize screen reader accessibility, lay out checkboxes vertically rather th
 
 {::nomarkdown}
 <div class="m-form-field m-form-field__checkbox">
-    <input class="a-checkbox focus" type="checkbox" id="test_checkbox_basic_focus">
-    <label class="a-label" for="test_checkbox_basic_focus">Label</label>
+    <input class="a-checkbox hover" type="checkbox" id="test_checkbox_basic_hover">
+    <label class="a-label" for="test_checkbox_basic_hover">Label</label>
 </div>
-
 {:/nomarkdown}
 
 </div>
@@ -886,8 +885,8 @@ There are some issues with voiceover reading radio buttons. To get around this, 
 
 {::nomarkdown}
 <div class="m-form-field m-form-field__radio">
-    <input class="a-radio focused" type="radio" id="test_radio_basic_ocused">
-    <label class="a-label" for="test_radio_basic_focused">Label</label>
+    <input class="a-radio hover" type="radio" id="test_radio_basic_hover">
+    <label class="a-label" for="test_radio_basic_hover">Label</label>
 </div>
 {:/nomarkdown}
 
@@ -940,9 +939,9 @@ There are some issues with voiceover reading radio buttons. To get around this, 
 
 <br>
 
-<div class="content-66 content-first">
+## Large target areas 
 
-<h3 id="large-target">Checkboxes and radio buttons with large target areas</h3>
+<div class="content-66 content-first">
 
 For better usability, consider using checkboxes and radio buttons with large target areas. These are easier to interact with (especially on smaller screens) and harder to miss. They are especially desirable when the form will have heavy mobile usage. Given the amount of real estate they occupy, they’re probably not suited for all use cases; for example, they may not work well for terms of service agreement checkboxes.
 

--- a/page-components/form-fields.md
+++ b/page-components/form-fields.md
@@ -11,7 +11,7 @@ redirect_from: "/ui-toolkit/form-fields.html"
 - [Notifications](#notifications)
 - [Checkboxes](#checkboxes)
 - [Radio buttons](#radio-buttons)
-- [Large target areas](#large-target-areas)
+- [Large target areas](#checkboxes-and-radio-buttons-with-large-target-areas)
 - [Dropdowns](#dropdowns)
 - [Range sliders](#range-sliders)
 {: class="toc"}
@@ -939,7 +939,7 @@ There are some issues with voiceover reading radio buttons. To get around this, 
 
 <br>
 
-## Large target areas 
+## Checkboxes and radio buttons with large target areas 
 
 <div class="content-66 content-first">
 


### PR DESCRIPTION
Separated out "Large target areas" into its own section and added to jump links menu. This makes more sense for the page hierarchy. There is still a future need to break this page up into separate pages but this update makes the most sense in the short term. 

## Additions
- Separated out "Large target areas" into its own section and added to jump links menu. 

## Removals
-

## Changes
-

## Testing

-

## Review

- @ielerol 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots
<img width="803" alt="screen shot 2017-09-13 at 6 50 16 pm" src="https://user-images.githubusercontent.com/6887128/30404732-02b200fe-98b6-11e7-9a46-49eb71c8eea8.png">
<img width="766" alt="screen shot 2017-09-13 at 6 50 24 pm" src="https://user-images.githubusercontent.com/6887128/30404731-02b08fd0-98b6-11e7-9611-6686bbcae462.png">





## Notes
-


## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
