### PR TITLE
Self hosted fonts update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -376,9 +366,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
+        "JSONStream": "1.3.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -398,7 +388,6 @@
       "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -420,6 +409,7 @@
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
+        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -516,12 +506,18 @@
       "integrity": "sha1-BxPLdYckemMqnwjPG9FpuHi2Koo=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.10.0",
         "browserify-cache-api": "3.0.1",
+        "JSONStream": "0.10.0",
         "through2": "2.0.3",
         "xtend": "4.0.1"
       },
       "dependencies": {
+        "jsonparse": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
+          "dev": true
+        },
         "JSONStream": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
@@ -531,12 +527,6 @@
             "jsonparse": "0.0.5",
             "through": "2.3.8"
           }
-        },
-        "jsonparse": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
-          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
-          "dev": true
         }
       }
     },
@@ -747,9 +737,9 @@
       }
     },
     "cf-typography": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.3.0.tgz",
-      "integrity": "sha512-4mAINE6bnFu9SlNIk455ahgW9HCT2CYtIjOY75xAmPzjtbo6ln1RUIGdpB5XU0RGGJOAq7YE9nFSnM8ikLTqeA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.4.0.tgz",
+      "integrity": "sha512-3X//g6MefNImIwZK/fTAg1JlER2wEmmMHkquv6llJOouOWFdX1Ff/pHtKFQtbQPDgmaPfZDUNlDXsxGaK4w5XQ==",
       "requires": {
         "cf-core": "4.5.1",
         "cf-icons": "4.2.1"
@@ -2415,6 +2405,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2423,14 +2421,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3367,10 +3357,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
+        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -3650,6 +3640,16 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -3970,7 +3970,6 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -3978,6 +3977,7 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
+        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cf-notifications": "^1.0.2",
     "cf-pagination": "^4.2.1",
     "cf-tables": "^4.1.6",
-    "cf-typography": "^4.3.0",
+    "cf-typography": "^4.4.0",
     "html5shiv": "latest",
     "jquery": "~1.11.0",
     "normalize-css": "^2.0.0",

--- a/src/static/css/main.less
+++ b/src/static/css/main.less
@@ -16,8 +16,6 @@
 @import (less) "cf-typography.less";
 
 // Font variables
-@import (less) 'licensed-fonts.css';
-
 @webfont-regular: 'AvenirNextLTW01-Regular';
 @webfont-italic: 'AvenirNextLTW01-Italic';
 @webfont-medium: 'AvenirNextLTW01-Medium';
@@ -25,6 +23,12 @@
 
 // Icon font path
 @cf-icon-path:                  '../fonts';
+
+// Webfont variables
+// This is the path for self-hosted fonts.
+@cf-fonts-path: '/static/fonts';
+// Whether or not to override the local path and retrieve fonts from fonts.net.
+@use-font-cdn: true;
 
 // Import site-specific Less files
 @import (less) "header.less";

--- a/src/static/css/main.less
+++ b/src/static/css/main.less
@@ -19,9 +19,12 @@
 @import (less) 'licensed-fonts.css';
 
 @webfont-regular: 'AvenirNextLTW01-Regular';
-@webfont-italic: 'AvenirNextLTW01-Italic';
-@webfont-medium: 'AvenirNextLTW01-Medium';
-@webfont-demi: 'AvenirNextLTW01-Demi';
+@webfont-italic: 'AvenirNextLTW01-Regular';
+@webfont-medium: 'AvenirNextLTW01-Regular';
+@webfont-demi: 'AvenirNextLTW01-Regular';
+// @webfont-italic: 'AvenirNextLTW01-Italic';
+// @webfont-medium: 'AvenirNextLTW01-Medium';
+// @webfont-demi: 'AvenirNextLTW01-Demi';
 
 // Icon font path
 @cf-icon-path:                  '../fonts';

--- a/src/static/css/main.less
+++ b/src/static/css/main.less
@@ -19,12 +19,9 @@
 @import (less) 'licensed-fonts.css';
 
 @webfont-regular: 'AvenirNextLTW01-Regular';
-@webfont-italic: 'AvenirNextLTW01-Regular';
-@webfont-medium: 'AvenirNextLTW01-Regular';
-@webfont-demi: 'AvenirNextLTW01-Regular';
-// @webfont-italic: 'AvenirNextLTW01-Italic';
-// @webfont-medium: 'AvenirNextLTW01-Medium';
-// @webfont-demi: 'AvenirNextLTW01-Demi';
+@webfont-italic: 'AvenirNextLTW01-Italic';
+@webfont-medium: 'AvenirNextLTW01-Medium';
+@webfont-demi: 'AvenirNextLTW01-Demi';
 
 // Icon font path
 @cf-icon-path:                  '../fonts';


### PR DESCRIPTION
Updates DM to use the latest version of `cf-typography` which enables self-hosted fonts on consumerfinance.gov. Here in the Design Manual, the CDN fonts will still be served from fastfonts.net, which requires the update to `main.less` that this PR includes.

## Additions

- New required web font variables, `@cf-fonts-path` and `@use-font-cdn`

## Removals

- Removed local `licensed-fonts.css` file; these fonts are now included via the `cf-typography` component.

## Changes

-

## Testing

- `bundle install`
- `npm install`
- `grunt build`
- `npm start`
- go to http://localhost:4000/brand-guidelines/typography.html and confirm webfonts load as expected
- change `@use-font-cdn: true;` value to `false` to test that fonts 404 in that scenario

## Review

- @anselmbradford 
- @jimmynotjim 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
