### PR TITLE
Update the Travis config to use NPM 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
 node_js:
   - '8'
+before_install:
+  - npm i -g npm@4.2.0
+before_script:
+  - npm i -g grunt-cli
+script:
+  - npm run build


### PR DESCRIPTION
There is a bug in NPM 5 that is causing the install to fail. Downgrading
to NPM 4 for the time being. Also added steps to install grunt and
ensure the project assets successfully build.

## Additions

- Added Grunt install step to Travis config
- Added Grunt build step to Travis config

## Changes

- Updated Travis config to use NPM 4

## Testing

- Wait for Travis to report back

[Preview this PR without the whitespace changes](?w=0)
