### PR TITLE
Correct a broken link in the data visualization section

### DIFF
--- a/data-visualization/accessibility.md
+++ b/data-visualization/accessibility.md
@@ -13,14 +13,15 @@ published: true
 Allowing all users to be able to comprehend charts and graphics is a key part
 of being a government agency that serves the entire American public. This is an
 interpretation of what it means for a chart to be 508 compliant and accessible,
-starting with descriptive titles (see the [Data visualization text
-  section](text.html)) and not only relying on color to connect data to its
-  meaning (see the [Data visualization color section](color.html)).
+starting with descriptive titles (see the [Data visualization chart components
+subsection on titles](chart-components.html#titles)) and not only relying on
+color to connect data to its meaning (with details in the [Data visualization
+color section](color.html)).
 {: class="lead-in"}
 
 ##### Key questions
 * How would someone using a screen reader interact with this visualization?
-* How would someone with low vision interact with this visualisation?
+* How would someone with low vision interact with this visualization?
 
 ### Alt tags
 Alt tags are what a screen reader will say instead of the image. This is


### PR DESCRIPTION
Correct a broken link and revise some text. (The data visualization section was re-organized months ago, but the text and links weren't updated to match.)

## Changes

- Change a link so it no longer returns a 404.
- Correct a British English spelling to use the American English spelling.

## Review

- @amycesal (who first reported this; thank you!)
- @Scotchester 

## Screenshots

### Current 

First link tries to go to the Text section, which doesn't exist.
![screen shot 2018-02-23 at 11 14 32 am](https://user-images.githubusercontent.com/1183435/36604146-df8e3a02-188a-11e8-85d3-208172057484.png)

### Changed

First link goes to the Titles area of the Chart Components section, which does exist. Also the spelling of "visualization" is Americanized in the second bullet under "Key Questions".
![screen shot 2018-02-23 at 11 15 01 am](https://user-images.githubusercontent.com/1183435/36604155-e53bd82e-188a-11e8-941f-810d5e979c1c.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
