### PR TITLE
Add instructions to update the color palette

### DIFF
--- a/brand-guidelines/color-principles.md
+++ b/brand-guidelines/color-principles.md
@@ -140,3 +140,16 @@ Tints expand upon the primary and secondary color palettes to help create visual
     {% endfor %}
     </table>
 {:/nomarkdown}
+
+
+## Updating the color palette
+
+To update the color palette within the Design Manual:
+
+1. Update the values within the [CFPB Brand Colors CSV file](https://github.com/cfpb/design-manual/blob/gh-pages/_data/cfpb-brand-colors.csv)
+1. From terminal within this repo run `npm run colors`, this will auto-generate a [new brand-palette.less file](https://github.com/cfpb/design-manual/blob/gh-pages/src/static/css/brand-palette.less)
+1. Run `grunt build` (you may need the `-f` flag because of linting issues)
+1. Run `npm start` and check `/design-manual/brand-guidelines/color-principles.html` locally
+1. Commit the changes and open a PR.
+
+Once the PR is merged, the Less file needs to be duplicated [in Capital Framework CF Core](https://github.com/cfpb/capital-framework/tree/canary/src/cf-core/src) and follow that project's release process.


### PR DESCRIPTION
Forgot to add the documentation for updating the color palette after we finished the color generator scripts last year. Better late than never 😝 

## Additions

- Color palette instructions

## Testing

- Follow the instructions.

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

<img width="730" alt="screen shot 2018-07-02 at 4 18 22 pm" src="https://user-images.githubusercontent.com/1280430/42186786-890b34ca-7e13-11e8-93c8-18dadda349fd.png">


## Notes

- Fixes #505

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
