### PR TITLE
Update hero illustration specs

### DIFF
--- a/global-elements/heroes.md
+++ b/global-elements/heroes.md
@@ -120,7 +120,7 @@ Subheading content should be brief, enticing, and build upon the heading to desc
 
 <h4>Illustration (no bleed)</h4>
 - Single image for both large and small screens
-- Illustration dimensions (maximum): 470px x 195px (2x: 940px x 390px)
+- Illustration dimensions: 470px (exact) x 195px (maximum) (2x: 940px x 390px)
 
 <div class="content-50 content-last">
   <p>Large screens (601+)</p>


### PR DESCRIPTION
The specs for the standard hero illustration were a little unclear. The best way to be sure a hero won't be taller than 285 px is to make the illustration *exactly* 470 px wide by a *maximum* of 195 px tall. I updated the relevant illustration specs to clarify that.

## Changes

- Updated the no-bleed illustration size specs

## Testing

- Do the specs make sense as written now?

## Notes

- The format of `NNNpx (exact) x NNNpx (maximum)` is used elsewhere on this page, so I stuck with that to be consistent.